### PR TITLE
Fix duplicate titles in ToS and Privacy Policy

### DIFF
--- a/penguinbyte-guard/privacypolicy.html
+++ b/penguinbyte-guard/privacypolicy.html
@@ -11,9 +11,7 @@
 <body>
     <span id="title">Privacy Policy</span>
     <div class="container">
-        <textarea readonly disabled>Privacy Policy
-
-  PenguinByte Guard only collects the data it strictly needs. Here is the data that is collected and how it’s used:
+        <textarea readonly disabled> PenguinByte Guard only collects the data it strictly needs. Here is the data that is collected and how it’s used:
             
   1. PenguinByte Guard needs to access and read server messages for several functions like deleting messages and scanning messages for flagged words.
             

--- a/penguinbyte-guard/termsofservice.html
+++ b/penguinbyte-guard/termsofservice.html
@@ -11,9 +11,7 @@
 <body>
     <span id="title">Terms of Service</span>
     <div class="container">
-        <textarea readonly disabled>Terms of Service
-
-  PenguinByte Guard is a Discord server protection bot created by Lexerotk for the PenguinByte Discord Community and affiliated servers. PenguinByte Guard is licensed under the OSI-approved ISC license agreement.
+        <textarea readonly disabled> PenguinByte Guard is a Discord server protection bot created by Lexerotk for the PenguinByte Discord Community and affiliated servers. PenguinByte Guard is licensed under the OSI-approved ISC license agreement.
     
 ---
 


### PR DESCRIPTION
Remove unnecessary "Terms of Service" and "Privacy Policy" titles in textview