### PR TITLE
Fix naming and remove unnecessary duplicate titles

### DIFF
--- a/penguinbyte-guard/about.html
+++ b/penguinbyte-guard/about.html
@@ -12,7 +12,7 @@
 <body>
     <div class="container">
         <img id="logo" src="../assets/pbg2BANNER.png" alt="Couldn't load the image.">
-        <span class="text">A bot for keeping <a target="_blank" href="https://discord.gg/V4JQtnQksw">PenguinByte Discord Community</a> safe.</span>
+        <span class="text">A bot for keeping the <a target="_blank" href="https://discord.gg/V4JQtnQksw">PenguinByte Discord Community</a> safe.</span>
         <span class="text">Written with <a target="_blank" href="https://discord.js.org">Discord.js</a></span>
         <span class="text">Made by <a target="_blank" href="https://lexerotk.github.io">lexerotk</a></span>
         <div id="buttons">

--- a/penguinbyte-guard/about.html
+++ b/penguinbyte-guard/about.html
@@ -12,7 +12,7 @@
 <body>
     <div class="container">
         <img id="logo" src="../assets/pbg2BANNER.png" alt="Couldn't load the image.">
-        <span class="text">A bot for keeping <a target="_blank" href="https://discord.gg/V4JQtnQksw">PenguinByte Discord Server</a> safe.</span>
+        <span class="text">A bot for keeping <a target="_blank" href="https://discord.gg/V4JQtnQksw">PenguinByte Discord Community</a> safe.</span>
         <span class="text">Written with <a target="_blank" href="https://discord.js.org">Discord.js</a></span>
         <span class="text">Made by <a target="_blank" href="https://lexerotk.github.io">lexerotk</a></span>
         <div id="buttons">

--- a/penguinbyte-guard/privacypolicy.html
+++ b/penguinbyte-guard/privacypolicy.html
@@ -11,9 +11,7 @@
 <body>
     <span id="title">Privacy Policy</span>
     <div class="container">
-        <textarea readonly disabled>Privacy Policy
-
-  PenguinByte Guard only collects the data it strictly needs. Here is the data that is collected and how it’s used:
+        <textarea readonly disabled> PenguinByte Guard only collects the data it strictly needs. Here is the data that is collected and how it’s used:
             
   1. PenguinByte Guard needs to access and read server messages for several functions like deleting messages and scanning messages for flagged words.
             

--- a/penguinbyte-guard/termsofservice.html
+++ b/penguinbyte-guard/termsofservice.html
@@ -11,9 +11,7 @@
 <body>
     <span id="title">Terms of Service</span>
     <div class="container">
-        <textarea readonly disabled>Terms of Service
-
-  PenguinByte Guard is a Discord server protection bot created by Lexerotk for the PenguinByte Discord Community and affiliated servers. PenguinByte Guard is licensed under the OSI-approved ISC license agreement.
+        <textarea readonly disabled> PenguinByte Guard is a Discord server protection bot created by Lexerotk for the PenguinByte Discord Community and affiliated servers. PenguinByte Guard is licensed under the OSI-approved ISC license agreement.
     
 ---
 


### PR DESCRIPTION
Fixes some naming
Removes duplicate "Terms of Service" and "Privacy Policy" titles in textarea